### PR TITLE
derpfest: envsetup: set aosp_target_release before build-derpfest.sh

### DIFF
--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -661,6 +661,7 @@ function derpfest()
         echo "Couldn't locate the top of the tree. Try setting TOP." >&2
         return
     fi
+    source ${ANDROID_BUILD_TOP}/vendor/lineage/vars/aosp_target_release
     $T/vendor/lineage/tools/build-derpfest.sh "$@"
 }
 


### PR DESCRIPTION
In file included from build/make/core/config.mk:406: In file included from build/make/core/envsetup.mk:51: build/make/core/release_config.mk:273: error: No release config set for target; please set TARGET_RELEASE, or if building on the command line use 'lunch <target>-<release>-<build_type>', where release is one of: . 
08:58:37 dumpvars failed with: exit status 1

#### failed to build some targets (2 seconds) ####

Total time elapsed: 0 minutes 2 seconds